### PR TITLE
supress error when caching fails

### DIFF
--- a/controllers/query/result.js
+++ b/controllers/query/result.js
@@ -25,17 +25,22 @@ function ResultController (results, shouldCacheResults, req, res, next) {
                 count: count || 0 
             }
         }, function (err, html) {
+
+            // Send the response immediatly to the user. Even though
+            // the request gets a response the code below
+            // will still be executed. If there are any errors
+            // in the caching we don't really care to tell the 
+            // user.
+            res.send(html);
+
             if (cache) {
 
                 // Store the results in the database so that
                 // the next query with this querystring does
                 // not need to ask external components like bibsys
                 QueryFactory.create(queryString, results, function (err) {
-                    if (err) return next(err); 
-                    res.send(html);
+                    if (err) logger.error(err); 
                 });
-            } else {
-                res.send(html);
             }
         });
     }


### PR DESCRIPTION
dont show error to user if the caching did not work. this does not however fix the issue of dup_entry, it just supresses it for the user. issue #41 
